### PR TITLE
Fix: Correct Firebase auth initialization and export

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,6 +1,7 @@
   {/* // Import the functions you need from the SDKs you need */}
   import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
   import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-analytics.js";
+  import { getAuth, GoogleAuthProvider } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
   {/* // TODO: Add SDKs for Firebase products that you want to use
   // https://firebase.google.com/docs/web/setup#available-libraries */}
 
@@ -19,3 +20,7 @@
   {/* // Initialize Firebase */}
   const app = initializeApp(firebaseConfig);
   const analytics = getAnalytics(app);
+  const auth = getAuth(app);
+  const googleProvider = new GoogleAuthProvider();
+
+export { app, analytics, auth, googleProvider };


### PR DESCRIPTION
I resolved an issue where `src/firebase.js` was not properly initializing or exporting the Firebase `auth` service and `googleProvider`. This caused "module does not provide an export named 'auth'" errors in components attempting to import these services (e.g., `AuthContext.jsx`).

Changes made:
- I modified `src/firebase.js` to:
    - Import `getAuth` and `GoogleAuthProvider` from the Firebase SDK (using gstatic.com URLs for consistency with existing file style).
    - Initialize `auth = getAuth(app)`.
    - Initialize `googleProvider = new GoogleAuthProvider()`.
    - Export `auth` and `googleProvider` as named exports.

This ensures that Firebase authentication services are correctly set up and made available to the rest of your application, resolving the import errors.